### PR TITLE
Check for selection keywords presence upon validation

### DIFF
--- a/haddock_tbl_validation/distance-or.tbl
+++ b/haddock_tbl_validation/distance-or.tbl
@@ -1,4 +1,4 @@
-assign ( resid 201 and name  C18 ) ( resid 93 and name HG2+ ) 4.66 4.66 1.0
+assign ( byres resid 201 and not ( byres (name C19 or name C18))) ( resid 93 and name HG2+ ) 4.66 4.66 1.0
    or
        ( resid 201 and name  C22 ) ( resid 93 and name HG2+ )
    or

--- a/haddock_tbl_validation/distance-or_malformed.tbl
+++ b/haddock_tbl_validation/distance-or_malformed.tbl
@@ -1,0 +1,6 @@
+assign ( resid 201 and name  C18 ) ( resid 93 and name HG2+ ) 4.66 4.66 1.0
+   or
+       ( resid 201 and name  C22 ) ( resid 93 and HG2+ )
+   or
+       ( resid 205 and name  C22 ) ( resid 93 and name HG2+ )
+

--- a/haddock_tbl_validation/distance-or_malformed.tbl
+++ b/haddock_tbl_validation/distance-or_malformed.tbl
@@ -1,6 +1,6 @@
-assign ( resid 201 and name  C18 ) ( resid 93 and name HG2+ ) 4.66 4.66 1.0
+assign ( byres resid 201 and not ( byres (name C19 or name C18)) ) ( name 93 and HG2+ ) 4.66 4.66 1.0
    or
-       ( resid 201 and name  C22 ) ( resid 93 and HG2+ )
+       ( resid 201 and name C22 ) ( resid 93 and name HG2+ )
    or
-       ( resid 205 and name  C22 ) ( resid 93 and name HG2+ )
+       ( resid 205 and name C22 ) ( resid 93 and name HG2+ )
 


### PR DESCRIPTION
- List of allowed keywords: ('name', 'resn', 'atom', 'resi', 'attr', 'segi', 'chem', 'id', 'byres', 'not')
- Add "complex" syntax in distance_or.tbl file
- New distance_or_malformed.tbl to trigger "Missing/wrong selection keyword Exception"
- Make validate_tbl.py mostly PEP8 compliant