### PR TITLE
restrain_ligand.py handling 2-letter residue names

### DIFF
--- a/restrain_ligand.py
+++ b/restrain_ligand.py
@@ -49,7 +49,7 @@ for atom in atom_lst:
 
 ligand = None
 for residue in structure.get_residues():
-    if residue.resname == args.ligand:
+    if residue.resname.strip() == args.ligand.strip():
         ligand = residue
         break
 


### PR DESCRIPTION
Previously, restrain_ligand.py would only accept ZN or other ions if the residue name was given as ' ZN'. This is unintuitive and results in ugly output filenames that contain spaces. It would make more sense to strip whitespace when searching for residues. This means I can provide "ZN" as the residue name without encountering an error that the residue does not exist. This remains backwards-compatible, in that you can still provide " ZN" as the argument and the same output filename as before will be generated, in case some users have already scripted around this problem.