### PR TITLE
docker container added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM mambaorg/micromamba:latest
+USER root
+RUN apt-get update && apt-get install -y git acl libxml2-dev build-essential libcurl4-openssl-dev pkg-config m4 libtool automake autoconf libjson-c-dev libgl1-mesa-dev libgl-dev libc++-11-dev libc++abi-11-dev
+RUN setfacl -Rm u:micromamba:rwx /opt
+USER micromamba
+ENV BASE=/home/micromamba
+WORKDIR $BASE
+RUN git clone https://github.com/mittinatten/freesasa
+WORKDIR $BASE/freesasa
+RUN git submodule init && git submodule update
+RUN autoreconf -i
+RUN ./configure
+RUN make
+USER root
+RUN make install
+USER micromamba
+ADD ./ $BASE/haddock-tools
+WORKDIR $BASE/haddock-tools
+RUN micromamba env create -y -f $BASE/haddock-tools/environment.yaml
+USER root
+RUN make
+USER micromamba
+ENV ENV_NAME="haddock-tools"
+ENV PATH="$PATH:$BASE/haddock-tools:$BASE/freesasa"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ make
 cd haddock-tools && git pull origin master
 ```
 
+Alternatively you can use [haddock-tools docker container](quay.io/antonkulaga/haddock-tools:latest) that has all dependencies and freesasa preinstalled.
+
 Scripts
 ------------
 

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+docker build -t quay.io/antonkulaga/haddock-tools:latest .

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,13 @@
+name: haddock-tools
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - python=3.9
+  - biopython=1.79
+  - ihm=0.25
+  - pip=21.3.1
+  - pip:
+      - pdb-tools==2.4.1
+      - freesasa==2.1.0


### PR DESCRIPTION
Installing freesasa and haddock-tools dependencies is a pain, I made a docker container to make things easier for the user. So far I published it at my account but ready to transfer to whatever organizational account you have for haddock.
In my plans also creating a docker container for antibody protocol that will depend on haddock-tools container